### PR TITLE
Adds tests for access after unmemoize

### DIFF
--- a/lib/db_memoize/model.rb
+++ b/lib/db_memoize/model.rb
@@ -27,8 +27,6 @@ module DbMemoize
 
     def unmemoize(method_name = :all)
       if method_name != :all
-        # FIXME: this works, but isn't immediately visible on the record.
-        # See also note in create_memoized_value.
         memoized_values.where(method_name: method_name).delete_all
       else
         memoized_values.clear

--- a/spec/db_memoize/model_spec.rb
+++ b/spec/db_memoize/model_spec.rb
@@ -208,6 +208,12 @@ describe DbMemoize::Model do
         expect { @rec1.unmemoize }
           .to change { DbMemoize::Value.count }.by(-3)
       end
+
+      it 'does not use the cached value after unmemoizing any longer' do
+        @rec1.unmemoize
+        expect_any_instance_of(Bicycle).to receive(:facilities_without_memoize)
+        @rec1.facilities
+      end
     end
 
     context 'specific method only' do
@@ -222,6 +228,12 @@ describe DbMemoize::Model do
         it 'wipes cached values for given record' do
           expect { @rec1.unmemoize(:facilities) }
             .to change { DbMemoize::Value.count }.by(-1)
+        end
+
+        it 'does not use the cached value after unmemoizing any longer' do
+          @rec1.unmemoize(:facilities)
+          expect_any_instance_of(Bicycle).to receive(:facilities_without_memoize)
+          @rec1.facilities
         end
       end
     end


### PR DESCRIPTION
It seems that by virtue of using the Rails associations an
attribute is no longer cached on the ruby object after unmemoizing it.

This commit adds specs to verify this.