### PR TITLE
Delete memoized value in a strong and stable order.

### DIFF
--- a/lib/db_memoize/model.rb
+++ b/lib/db_memoize/model.rb
@@ -27,7 +27,6 @@ module DbMemoize
 
     def unmemoize(method_name = :all)
       self.class.unmemoize id, method_name
-      # @association_cache.delete :memoized_values
     end
 
     #

--- a/lib/db_memoize/value.rb
+++ b/lib/db_memoize/value.rb
@@ -3,5 +3,20 @@ module DbMemoize
     self.table_name = 'memoized_values'
 
     include DbMemoize::Metal
+
+    def self.delete_all_ordered
+      relation = self
+      relation = all unless is_a?(ActiveRecord::Relation)
+
+      sql = relation.select(:ctid).to_sql
+      connection.execute <<-SQL
+        DO $$DECLARE c record;
+        BEGIN
+          FOR c IN #{sql} ORDER BY ctid LOOP
+            DELETE FROM #{DbMemoize::Value.table_name} WHERE ctid = c.ctid;
+          END LOOP;
+        END$$;
+      SQL
+    end
   end
 end


### PR DESCRIPTION
This commit deletes records from the db_memoized table in a predefined 
and stable order. This should make sure that two transactions that 
should delete the same records, both do this in the same order, 
preventing dead lock situations.

Background: postgres does not let a user define the order in which rows
are deleted from a table, yet to have two transactions able to delete
the same row and not to deadlock we need something like this (or we
need to employ some locking mechanism instead.)

This patch runs a loop on the database server to delete all records
one by one, in ctid order. ctid ordering is stable unless one does
a DDL statement or VACUUMs the table, so I think we should be much
better than before.