### PR TITLE
Fixes potential conflict when writing time objects.

### DIFF
--- a/spec/db_memoize/model_spec.rb
+++ b/spec/db_memoize/model_spec.rb
@@ -114,10 +114,13 @@ describe DbMemoize::Model do
         expect(klass.find(instance2.id).gears_count).to eq(7)
       end
 
-      it 'performs benchmark for a number of values to be created' do
-        cnt = 10_000
+      it 'performs benchmark for a number of values to be 7' do
+        cnt = 1_000
+        cnt.times { klass.create! }
+
+        ids = klass.all.pluck(:id)
         benchmark = Benchmark.measure do
-          klass.memoize_values((1..cnt).to_a, gears_count: 7)
+          klass.memoize_values(ids, gears_count: 7)
         end
         STDERR.puts "storing #{cnt} values took #{benchmark.total.round(3)}s"
       end

--- a/spec/db_memoize/model_spec.rb
+++ b/spec/db_memoize/model_spec.rb
@@ -17,26 +17,14 @@ describe DbMemoize::Model do
   end
 
   describe '.db_memoized_methods' do
+    EXPECTED_METHODS = [ :fuel_consumption, :gears_count, :facilities, :wise_saying, :generic_value ]
+
     it 'returns list of methods to be memoized' do
-      expect(Bicycle.db_memoized_methods).to contain_exactly(:fuel_consumption, :gears_count, :facilities, :wise_saying)
+      expect(Bicycle.db_memoized_methods).to contain_exactly(*EXPECTED_METHODS)
     end
 
     it 'returns list of all methods to be memoized for subclass' do
-      expect(ElectricBicycle.db_memoized_methods).to contain_exactly(:fuel_consumption, :gears_count, :facilities, :wise_saying, :max_speed)
-    end
-  end
-
-  describe 'bugfixes' do
-    let(:instance) { create(:bicycle) }
-
-    context 'when storing a value which marshals contain a 0 byte' do
-      it 'works' do
-        expect {
-          fuel_consumption = instance.fuel_consumption
-          expect(fuel_consumption).to eq(0)
-        }.to change { DbMemoize::Value.count }.by(1)
-        expect(instance.fuel_consumption).to eq(0)
-      end
+      expect(ElectricBicycle.db_memoized_methods).to contain_exactly(*EXPECTED_METHODS, :max_speed)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+ENV['TZ']='UTC'
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require 'active_record'

--- a/spec/support/bicycle.rb
+++ b/spec/support/bicycle.rb
@@ -11,6 +11,11 @@ class Bicycle < ActiveRecord::Base
   end
   db_memoize :gears_count
 
+  def generic_value
+    -1
+  end
+  db_memoize :generic_value
+
   def facilities
     {
       gears: 5,


### PR DESCRIPTION
This change drops the ActiveRecord implementation of writing timestamps to the database. This lets us use the ON CONFLICT resolution strategy which should prevent invalid updates.

In order to do so we had to make sure timestamps with subsecond resolution are written properly. To make sure of that we have specs for each supported object type now.