### PR TITLE
Fix potential deadlocks, see #51567

### DIFF
--- a/lib/db_memoize/migrations.rb
+++ b/lib/db_memoize/migrations.rb
@@ -22,8 +22,7 @@ module DbMemoize
 
           -- entity_id/entity_table_name should have a better chance to be useful, since
           -- there is more variance in entity_ids than there is in entity_table_names.
-          CREATE UNIQUE INDEX IF NOT EXISTS memoized_attributes_idx2
-            ON db_memoize.memoized_values(entity_id, entity_table_name, method_name);
+          DROP INDEX IF EXISTS memoized_attributes_idx2;
         SQL
       end
     end

--- a/spec/db_memoize/model_spec.rb
+++ b/spec/db_memoize/model_spec.rb
@@ -28,6 +28,34 @@ describe DbMemoize::Model do
     end
   end
 
+  context 'when having multiple memoized values' do
+    let(:instance) { create(:bicycle) }
+
+    def reloaded_instance
+      instance.class.find instance.id
+    end
+
+    before do
+      instance.memoize_values gears_count: 3
+      instance.memoize_values gears_count: 5
+
+      100.times do
+        instance.memoize_values gears_count: 5
+      end
+      instance.memoize_values gears_count: 7
+    end
+
+    it 'created multiple values' do
+      expect(DbMemoize::Value.where(entity_table_name: "bicycles", entity_id: instance.id).count).to eq(103)
+    end
+
+    it 'always returns the most recent memoized value' do
+      instance.memoize_values gears_count: 7
+      expect(reloaded_instance.gears_count).to eq(7)
+      expect(instance.reload.gears_count).to eq(7)
+    end
+  end
+
   context 'reading/writing' do
     let(:instance) { create(:bicycle) }
 


### PR DESCRIPTION
https://issues.mediapeers.com/issues/51567

In order to prevent database level deadlocks we don't manage any unique
index on memoized values, instead we potentially write multiple entries,
and make sure to always return the freshest matching memoized value.