### PR TITLE
Allow newer rails gem versions in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,6 @@ Lint/MissingCopEnableDirective:
 
 Style/ModuleFunction:
   Enabled: false
+
+Style/IfUnlessModifier:
+  Enabled: false

--- a/db_memoize.gemspec
+++ b/db_memoize.gemspec
@@ -12,15 +12,16 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files`.split("\n").grep(%r{^(lib/|VERSION|LICENSE|README)})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'simple-sql', '>= 0.4.20', '~> 0'
-  spec.add_development_dependency 'railties', '~> 4.2'
-  spec.add_development_dependency 'activerecord', '~> 4.2.10'
+  spec.add_dependency 'simple-sql', '~> 0.5.23'
 
-  spec.add_development_dependency 'rake', '~> 12.0'
-  spec.add_development_dependency 'pg', '~> 0.20'
-  spec.add_development_dependency 'rspec', '~> 3.8'
-  spec.add_development_dependency 'simplecov', '~> 0.17'
-  spec.add_development_dependency 'rubocop', '~> 0.59.2'
+  spec.add_development_dependency 'railties',     '> 4.2'
+  spec.add_development_dependency 'activerecord', '> 4.2'
+  spec.add_development_dependency 'rake',         '~> 12.0'
+  spec.add_development_dependency 'pg',           '~> 0.20'
+
+  spec.add_development_dependency 'rspec',            '~> 3.8'
+  spec.add_development_dependency 'simplecov',        '~> 0.17'
+  spec.add_development_dependency 'rubocop',          '~> 0.59.2'
   spec.add_development_dependency 'database_cleaner', '~> 1.5.3'
-  spec.add_development_dependency 'factory_bot', '~> 4.10.0'
+  spec.add_development_dependency 'factory_bot',      '~> 4.10.0'
 end

--- a/db_memoize.gemspec
+++ b/db_memoize.gemspec
@@ -14,14 +14,14 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'simple-sql', '~> 0.5.23'
 
-  spec.add_development_dependency 'railties',     '> 4.2'
-  spec.add_development_dependency 'activerecord', '> 4.2'
+  spec.add_development_dependency 'railties',     '> 4.2', '< 6'
+  spec.add_development_dependency 'activerecord', '> 4.2', '< 6'
   spec.add_development_dependency 'rake',         '~> 12.0'
   spec.add_development_dependency 'pg',           '~> 0.20'
 
   spec.add_development_dependency 'rspec',            '~> 3.8'
   spec.add_development_dependency 'simplecov',        '~> 0.17'
   spec.add_development_dependency 'rubocop',          '~> 0.59.2'
-  spec.add_development_dependency 'database_cleaner', '~> 1.5.3'
+  spec.add_development_dependency 'database_cleaner', '~> 1.6.2'
   spec.add_development_dependency 'factory_bot',      '~> 4.10.0'
 end

--- a/lib/db_memoize/model.rb
+++ b/lib/db_memoize/model.rb
@@ -107,13 +107,13 @@ module DbMemoize
 
       # rubocop:disable Style/EmptyBlockParameter
       def create_memoized_alias_method(method_name)
-        define_method "#{method_name}_with_memoize" do ||
-          memoized_value(method_name)
+        unless method_defined?("#{method_name}_without_memoize")
+          alias_method "#{method_name}_without_memoize", method_name
         end
 
-        # TODO: replace no longer existing alias_method_chain with s.th. else.
-        # like prepend, see https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/
-        alias_method_chain method_name, :memoize
+        define_method method_name do ||
+          memoized_value(method_name)
+        end
       end
 
       # rubocop:disable Style/GuardClause

--- a/lib/db_memoize/model.rb
+++ b/lib/db_memoize/model.rb
@@ -111,6 +111,8 @@ module DbMemoize
           memoized_value(method_name)
         end
 
+        # TODO: replace no longer existing alias_method_chain with s.th. else.
+        # like prepend, see https://www.justinweiss.com/articles/rails-5-module-number-prepend-and-the-end-of-alias-method-chain/
         alias_method_chain method_name, :memoize
       end
 


### PR DESCRIPTION
Hovewer we still need to replace `alias_method_chain` with s.th. else as it was removed in Rails 5